### PR TITLE
Fix AsString to avoid KeyNotFoundException

### DIFF
--- a/src/Oragon.RabbitMQ/Extensions.RabbitMQ.cs
+++ b/src/Oragon.RabbitMQ/Extensions.RabbitMQ.cs
@@ -133,19 +133,24 @@ public static class RabbitMQExtensions
     /// <returns></returns>
     public static string AsString(this IDictionary<string, object> dic, string key)
     {
-        var content = dic?[key] ?? null;
-
-        if (content != null)
+        if (dic is null)
         {
-            if (content is byte[] contentInBytes)
-            {
-                return Encoding.UTF8.GetString(contentInBytes);
-            }
+            return null;
+        }
 
-            if (content is string contentInString)
-            {
-                return contentInString;
-            }
+        if (!dic.TryGetValue(key, out var content) || content is null)
+        {
+            return null;
+        }
+
+        if (content is byte[] contentInBytes)
+        {
+            return Encoding.UTF8.GetString(contentInBytes);
+        }
+
+        if (content is string contentInString)
+        {
+            return contentInString;
         }
 
         return null;

--- a/tests/Oragon.RabbitMQ.UnitTests/Oragon_RabbitMQ/AsStringExtensionsTests.cs
+++ b/tests/Oragon.RabbitMQ.UnitTests/Oragon_RabbitMQ/AsStringExtensionsTests.cs
@@ -1,0 +1,35 @@
+using System.Text;
+using System.Collections.Generic;
+using Oragon.RabbitMQ;
+
+namespace Oragon.RabbitMQ.UnitTests.Oragon_RabbitMQ;
+
+public class AsStringExtensionsTests
+{
+    [Fact]
+    public void AsString_Returns_Null_When_Key_Missing()
+    {
+        IDictionary<string, object> headers = new Dictionary<string, object>();
+        string result = headers.AsString("missing");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void AsString_Returns_Null_When_Dictionary_Null()
+    {
+        IDictionary<string, object> headers = null;
+        string result = headers.AsString("missing");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void AsString_Returns_String_From_ByteArray()
+    {
+        IDictionary<string, object> headers = new Dictionary<string, object>
+        {
+            {"data", Encoding.UTF8.GetBytes("hello")}
+        };
+        string result = headers.AsString("data");
+        Assert.Equal("hello", result);
+    }
+}


### PR DESCRIPTION
## Summary
- prevent `AsString` from throwing when the key doesn't exist
- test extension behavior for null dictionaries, missing keys, and byte arrays

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843156a38048328863886b0fefdbb30