### PR TITLE
Populate ContentType and ContentEncoding during serialization

### DIFF
--- a/src/Oragon.RabbitMQ.Serializer.NewtonsoftJson/Serialization/NewtonsoftAMQPSerializer.cs
+++ b/src/Oragon.RabbitMQ.Serializer.NewtonsoftJson/Serialization/NewtonsoftAMQPSerializer.cs
@@ -75,12 +75,14 @@ public class NewtonsoftAmqpSerializer(JsonSerializerSettings options) : IAmqpSer
     {
         ArgumentNullException.ThrowIfNull(basicProperties);
 
+        ApplyContentMetadata(basicProperties);
+
         return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message, this.options));
     }
 
     /// <summary>
-    /// Serialize a message using Newtonsoft.Json  
-    /// </summary>    
+    /// Serialize a message using Newtonsoft.Json
+    /// </summary>
     /// <param name="basicProperties"></param>
     /// <param name="message"></param>
     /// <returns></returns>
@@ -88,7 +90,26 @@ public class NewtonsoftAmqpSerializer(JsonSerializerSettings options) : IAmqpSer
     {
         ArgumentNullException.ThrowIfNull(basicProperties);
 
+        ApplyContentMetadata(basicProperties);
+
         return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message, this.options));
+    }
+
+    // Declares the wire format on the message itself, so consumers on other stacks can
+    // negotiate through the standard AMQP headers instead of assuming JSON. Values already
+    // set by the caller win: BasicPropertiesConfigureAction runs before serialization and
+    // may have chosen a more specific media type, such as application/vnd.acme+json.
+    private static void ApplyContentMetadata(BasicProperties basicProperties)
+    {
+        if (string.IsNullOrEmpty(basicProperties.ContentType))
+        {
+            basicProperties.ContentType = "application/json";
+        }
+
+        if (string.IsNullOrEmpty(basicProperties.ContentEncoding))
+        {
+            basicProperties.ContentEncoding = "utf-8";
+        }
     }
 }
 

--- a/src/Oragon.RabbitMQ.Serializer.SystemTextJson/Serialization/SystemTextJsonAMQPSerializer.cs
+++ b/src/Oragon.RabbitMQ.Serializer.SystemTextJson/Serialization/SystemTextJsonAMQPSerializer.cs
@@ -78,12 +78,14 @@ public class SystemTextJsonAmqpSerializer(JsonSerializerOptions options) : IAmqp
     {
         ArgumentNullException.ThrowIfNull(basicProperties);
 
+        ApplyContentMetadata(basicProperties);
+
         return Encoding.UTF8.GetBytes(JsonSerializer.Serialize(message, this.options));
     }
 
     /// <summary>
-    /// Serialize a message using System.Text.Json  
-    /// </summary>    
+    /// Serialize a message using System.Text.Json
+    /// </summary>
     /// <param name="basicProperties"></param>
     /// <param name="message"></param>
     /// <returns></returns>
@@ -91,7 +93,26 @@ public class SystemTextJsonAmqpSerializer(JsonSerializerOptions options) : IAmqp
     {
         ArgumentNullException.ThrowIfNull(basicProperties);
 
+        ApplyContentMetadata(basicProperties);
+
         return Encoding.UTF8.GetBytes(JsonSerializer.Serialize(message, this.options));
+    }
+
+    // Declares the wire format on the message itself, so consumers on other stacks can
+    // negotiate through the standard AMQP headers instead of assuming JSON. Values already
+    // set by the caller win: BasicPropertiesConfigureAction runs before serialization and
+    // may have chosen a more specific media type, such as application/vnd.acme+json.
+    private static void ApplyContentMetadata(BasicProperties basicProperties)
+    {
+        if (string.IsNullOrEmpty(basicProperties.ContentType))
+        {
+            basicProperties.ContentType = "application/json";
+        }
+
+        if (string.IsNullOrEmpty(basicProperties.ContentEncoding))
+        {
+            basicProperties.ContentEncoding = "utf-8";
+        }
     }
 }
 

--- a/tests/Oragon.RabbitMQ.UnitTests/Oragon_RabbitMQ_Serializers/NewtonsoftAMQPSerializerTests.cs
+++ b/tests/Oragon.RabbitMQ.UnitTests/Oragon_RabbitMQ_Serializers/NewtonsoftAMQPSerializerTests.cs
@@ -36,6 +36,55 @@ public class NewtonsoftAmqpSerializerTests
     }
 
     [Fact]
+    public void SerializationShouldPopulateContentMetadata()
+    {
+        var targetBasicProperties = new BasicProperties();
+
+        var sourceObject = new Teste() { Name = "Oragon.RabbitMQ", Age = 2 };
+
+        var serializer = new NewtonsoftAmqpSerializer(null);
+
+        _ = serializer.Serialize(targetBasicProperties, sourceObject);
+
+        Assert.Equal("application/json", targetBasicProperties.ContentType);
+        Assert.Equal("utf-8", targetBasicProperties.ContentEncoding);
+    }
+
+    [Fact]
+    public void SerializationOfObjectShouldPopulateContentMetadata()
+    {
+        var targetBasicProperties = new BasicProperties();
+
+        object sourceObject = new Teste() { Name = "Oragon.RabbitMQ", Age = 2 };
+
+        var serializer = new NewtonsoftAmqpSerializer(null);
+
+        _ = serializer.Serialize(targetBasicProperties, sourceObject);
+
+        Assert.Equal("application/json", targetBasicProperties.ContentType);
+        Assert.Equal("utf-8", targetBasicProperties.ContentEncoding);
+    }
+
+    [Fact]
+    public void SerializationShouldPreserveContentMetadataDefinedByCaller()
+    {
+        var targetBasicProperties = new BasicProperties()
+        {
+            ContentType = "application/vnd.acme.order.v2+json",
+            ContentEncoding = "gzip",
+        };
+
+        var sourceObject = new Teste() { Name = "Oragon.RabbitMQ", Age = 2 };
+
+        var serializer = new NewtonsoftAmqpSerializer(null);
+
+        _ = serializer.Serialize(targetBasicProperties, sourceObject);
+
+        Assert.Equal("application/vnd.acme.order.v2+json", targetBasicProperties.ContentType);
+        Assert.Equal("gzip", targetBasicProperties.ContentEncoding);
+    }
+
+    [Fact]
     public void DeserializationTest()
     {
         var basicProperties = new BasicProperties();

--- a/tests/Oragon.RabbitMQ.UnitTests/Oragon_RabbitMQ_Serializers/SystemTextJsonAMQPSerializerTests.cs
+++ b/tests/Oragon.RabbitMQ.UnitTests/Oragon_RabbitMQ_Serializers/SystemTextJsonAMQPSerializerTests.cs
@@ -38,6 +38,55 @@ public class SystemTextJsonAmqpSerializerTests
     }
 
     [Fact]
+    public void SerializationShouldPopulateContentMetadata()
+    {
+        var targetBasicProperties = new BasicProperties();
+
+        var sourceObject = new Teste() { Name = "Oragon.RabbitMQ", Age = 2 };
+
+        var serializer = new SystemTextJsonAmqpSerializer(null);
+
+        _ = serializer.Serialize(targetBasicProperties, sourceObject);
+
+        Assert.Equal("application/json", targetBasicProperties.ContentType);
+        Assert.Equal("utf-8", targetBasicProperties.ContentEncoding);
+    }
+
+    [Fact]
+    public void SerializationOfObjectShouldPopulateContentMetadata()
+    {
+        var targetBasicProperties = new BasicProperties();
+
+        object sourceObject = new Teste() { Name = "Oragon.RabbitMQ", Age = 2 };
+
+        var serializer = new SystemTextJsonAmqpSerializer(null);
+
+        _ = serializer.Serialize(targetBasicProperties, sourceObject);
+
+        Assert.Equal("application/json", targetBasicProperties.ContentType);
+        Assert.Equal("utf-8", targetBasicProperties.ContentEncoding);
+    }
+
+    [Fact]
+    public void SerializationShouldPreserveContentMetadataDefinedByCaller()
+    {
+        var targetBasicProperties = new BasicProperties()
+        {
+            ContentType = "application/vnd.acme.order.v2+json",
+            ContentEncoding = "gzip",
+        };
+
+        var sourceObject = new Teste() { Name = "Oragon.RabbitMQ", Age = 2 };
+
+        var serializer = new SystemTextJsonAmqpSerializer(null);
+
+        _ = serializer.Serialize(targetBasicProperties, sourceObject);
+
+        Assert.Equal("application/vnd.acme.order.v2+json", targetBasicProperties.ContentType);
+        Assert.Equal("gzip", targetBasicProperties.ContentEncoding);
+    }
+
+    [Fact]
     public void DeserializationTest()
     {
         var basicProperties = new BasicProperties();


### PR DESCRIPTION
## What changed

Both JSON serializers now stamp the AMQP content metadata while serializing:

- `basicProperties.ContentType = "application/json"`
- `basicProperties.ContentEncoding = "utf-8"`

Applied to all four `Serialize` methods, via a private `ApplyContentMetadata` helper in each serializer.

## Why

`IAmqpSerializer.Serialize` receives a `BasicProperties` instance and neither implementation ever wrote to it -- they only null-checked it. Published messages therefore carried no `ContentType`, leaving consumers on other stacks unable to negotiate the format through the standard AMQP header.

The parameter was never vestigial. It is a design hook that was left unimplemented, and the call sites prove it: in every one, the instance handed to `Serialize` is the same object passed to `BasicPublishAsync`, so an in-place write reaches the wire.

| Call site | Pattern |
|---|---|
| `ForwardResult.cs:123-129` | `forwardBasicProperties` in both `basicProperties:` and `Serialize(...)` |
| `ReplyResult.cs:62-68` | same, with `replyBasicProperties` |
| `MessagePublisher.cs:253-257` (sample) | `Serialize` called before publish, same `properties` variable |

The codebase was already asymmetric about this: it *reads* `ContentType` for convention binding (`ArgumentBinderExtensions.cs:111-112`) and *propagates* it via `AmqpPropertyCopy.Content` (`RequeueToTailResult.cs:68-69`). It simply never originated the value.

The alternative considered -- dropping the parameter from `IAmqpSerializer` -- would have removed the only extension point available to custom serializers, and charged a breaking change for it. Only the serializer knows which format it produced; a Protobuf implementation would stamp `application/x-protobuf`. Moving that decision to the call site would force every result action to know every serializer's format.

## Precedence: caller wins

The stamp is applied only when the value is empty. In `ForwardResult.cs:115`, `BasicPropertiesConfigureAction` runs 13 lines *before* `Serialize`, so an unconditional assignment would silently discard an explicit choice:

```csharp
.WithBasicProperties((msg, props) => props.ContentType = "application/vnd.acme.order.v2+json")
```

## Tests

Six new tests (three per serializer): stamping on the generic overload, stamping on the `object` overload, and preservation of caller-defined values. Full unit suite: **214/214 passing**.

Worth noting that `SerializationShouldPreserveContentMetadataDefinedByCaller` also pins the reference-type semantics of `BasicProperties`. `BasicPublishAsync<TProperties>` is generic and the client library already ships `EmptyBasicProperty` as a `readonly struct` -- if `BasicProperties` ever became a value type, this test fails loudly instead of silently publishing messages without headers.

## Notes for reviewers

- **No characterization test was removed.** A test named `SerializeShouldNotPopulateContentType` was believed to document the previous behavior, but no such test (nor the string `Characterization`) exists anywhere in the repository. Nothing pinned the old behavior as intentional.
- **The helper is duplicated across both serializer packages** rather than promoted to `Oragon.RabbitMQ.Abstractions`. Twelve lines in two independent assemblies did not seem worth new permanent public API surface; worth extracting if a third serializer appears.
- **`ContentEncoding = "utf-8"` is convention over strict correctness.** The AMQP 0-9-1 field mirrors MIME `Content-Encoding` (compression: `gzip`, `deflate`), and RFC 8259 already defines JSON as UTF-8, making the charset redundant. The RabbitMQ .NET ecosystem has used `"utf-8"` there for years, and interoperability was weighted above purism -- happy to drop it if you prefer.
- **Behavior change on the wire.** Messages published through `ReplyResult` / `ForwardResult` now carry headers they did not before. Benign for existing consumers, but it is observable.
- **Docs not updated.** `docs/src/app/docs/serialization/page.md` does not mention `ContentType` at all; a follow-up should document the override path and the convention for custom `IAmqpSerializer` implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
