### PR TITLE
Fix byte[] vs byte[] comparison in QueueArgumentDiagnostics

### DIFF
--- a/src/Oragon.RabbitMQ/Topology/QueueArgumentDiagnostics.cs
+++ b/src/Oragon.RabbitMQ/Topology/QueueArgumentDiagnostics.cs
@@ -73,6 +73,11 @@ public static class QueueArgumentDiagnostics
             return string.Equals(Encoding.UTF8.GetString(expectedBytes), actualString, StringComparison.Ordinal);
         }
 
+        if (expected is byte[] expectedArray && actual is byte[] actualArray)
+        {
+            return expectedArray.AsSpan().SequenceEqual(actualArray);
+        }
+
         return expected.Equals(actual);
     }
 

--- a/tests/Oragon.RabbitMQ.UnitTests/Oragon_RabbitMQ/QueueArgumentsTests.cs
+++ b/tests/Oragon.RabbitMQ.UnitTests/Oragon_RabbitMQ/QueueArgumentsTests.cs
@@ -53,4 +53,48 @@ public class QueueArgumentsTests
 
         Assert.DoesNotContain(differences, difference => difference.Key == QueueArguments.MaxPriorityKey);
     }
+
+    [Fact]
+    public void QueueArgumentDiagnostics_WhenBothValuesAreEquivalentByteArrays_ShouldNotReportDifference()
+    {
+        // Arrange
+        var expected = new Dictionary<string, object>
+        {
+            [QueueArguments.DeadLetterExchangeKey] = "dead-letter-exchange"u8.ToArray(),
+        };
+
+        var actual = new Dictionary<string, object>
+        {
+            [QueueArguments.DeadLetterExchangeKey] = "dead-letter-exchange"u8.ToArray(),
+        };
+
+        // Act
+        IReadOnlyList<QueueArgumentDifference> differences = QueueArgumentDiagnostics.Compare(expected, actual);
+
+        // Assert
+        Assert.Empty(differences);
+    }
+
+    [Fact]
+    public void QueueArgumentDiagnostics_WhenByteArraysHaveDifferentContent_ShouldReportDifference()
+    {
+        // Arrange
+        var expected = new Dictionary<string, object>
+        {
+            [QueueArguments.DeadLetterExchangeKey] = "dead-letter-exchange"u8.ToArray(),
+        };
+
+        var actual = new Dictionary<string, object>
+        {
+            [QueueArguments.DeadLetterExchangeKey] = "another-exchange"u8.ToArray(),
+        };
+
+        // Act
+        IReadOnlyList<QueueArgumentDifference> differences = QueueArgumentDiagnostics.Compare(expected, actual);
+
+        // Assert
+        QueueArgumentDifference difference = Assert.Single(differences);
+        Assert.Equal(QueueArguments.DeadLetterExchangeKey, difference.Key);
+        Assert.Equal(QueueArgumentDifferenceType.Different, difference.Type);
+    }
 }


### PR DESCRIPTION
## O que mudou

`QueueArgumentDiagnostics.ValuesEqual` ganhou uma branch para o par `byte[]` vs `byte[]`, comparando conteúdo via `AsSpan().SequenceEqual` antes do fallback genérico.

## Por quê

O método já tratava `string` vs `byte[]` e `byte[]` vs `string`, mas não o par `byte[]` vs `byte[]`. Esse caso caía no fallback `expected.Equals(actual)` — que para arrays em .NET é `Object.Equals`, ou seja, **igualdade referencial**. Consequência: dois arrays com conteúdo idêntico eram reportados como `QueueArgumentDifferenceType.Different`.

Isso gera falsos positivos reais na comparação de topologia esperada contra a real, já que o RabbitMQ frequentemente devolve valores de argumentos de fila como `byte[]`.

## Testes

Dois testes novos em `QueueArgumentsTests`:

- `QueueArgumentDiagnostics_WhenBothValuesAreEquivalentByteArrays_ShouldNotReportDifference` — instâncias distintas com conteúdo igual não devem produzir diferença. Falha sem a correção.
- `QueueArgumentDiagnostics_WhenByteArraysHaveDifferentContent_ShouldReportDifference` — arrays com conteúdo distinto continuam sendo reportados como `Different`.

O segundo teste não é redundante: uma correção plausível porém errada (retornar `true` para qualquer par `byte[]`) passaria apenas no primeiro. O par positivo/negativo é o que dá poder de falsificação ao teste.

Suíte completa: 210 testes passando em `net9.0` e `net10.0`.

## Nota para quem revisar

O pedido original mencionava um teste de caracterização existente (`..._ShouldReportDifference`, marcado como "Characterization test") que documentaria o comportamento antigo e precisaria ser atualizado. **Esse teste não existe no repositório** — `QueueArgumentsTests` tinha apenas 2 testes, nenhum envolvendo `byte[]`, e não há ocorrência de "Characterization" em `tests/`. Portanto nada foi alterado ou removido; os dois testes acima são novos.

Vale notar também, como decisão de design pré-existente e fora do escopo deste PR: `Compare` percorre somente as chaves de `expected`, então argumentos presentes apenas na fila real são ignorados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
