### PR TITLE
Fix silent overflow in RabbitMQExtensions.Parallelism

### DIFF
--- a/src/Oragon.RabbitMQ/Extensions.RabbitMQ.cs
+++ b/src/Oragon.RabbitMQ/Extensions.RabbitMQ.cs
@@ -227,15 +227,17 @@ public static class RabbitMQExtensions
 
 
     /// <summary>
-    /// 
+    /// Set ConsumerDispatchConcurrency on ConnectionFactory
     /// </summary>
     /// <param name="connectionFactory"></param>
-    /// <param name="consumerDispatchConcurrency"></param>
+    /// <param name="consumerDispatchConcurrency">Must be between 1 and <see cref="ushort.MaxValue"/>.</param>
     /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="consumerDispatchConcurrency"/> is less than 1 or greater than <see cref="ushort.MaxValue"/>.</exception>
     public static ConnectionFactory Parallelism(this ConnectionFactory connectionFactory, int consumerDispatchConcurrency)
     {
         ArgumentNullException.ThrowIfNull(connectionFactory);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(consumerDispatchConcurrency);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(consumerDispatchConcurrency, ushort.MaxValue);
 
         connectionFactory.ConsumerDispatchConcurrency = (ushort)consumerDispatchConcurrency;
 

--- a/tests/Oragon.RabbitMQ.UnitTests/Oragon_RabbitMQ/Extensions.RabbitMQTests.cs
+++ b/tests/Oragon.RabbitMQ.UnitTests/Oragon_RabbitMQ/Extensions.RabbitMQTests.cs
@@ -184,6 +184,48 @@ public class Extensions_RabbitMQ_Tests
     }
 
 
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(ushort.MaxValue)]
+    public void Parallelism_Should_Set_ConsumerDispatchConcurrency_When_Concurrency_Is_Valid(int concurrency)
+    {
+        // Arrange
+        var connectionFactory = new ConnectionFactory();
+
+        // Act
+        ConnectionFactory result = connectionFactory.Parallelism(concurrency);
+
+        // Assert
+        Assert.Same(connectionFactory, result);
+        Assert.Equal((ushort)concurrency, result.ConsumerDispatchConcurrency);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(ushort.MaxValue + 1)]
+    [InlineData(int.MaxValue)]
+    public void Parallelism_Should_Throw_When_Concurrency_Is_Out_Of_UShort_Range(int concurrency)
+    {
+        // Arrange
+        var connectionFactory = new ConnectionFactory();
+
+        // Act & Assert
+        ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() => connectionFactory.Parallelism(concurrency));
+        Assert.Equal("consumerDispatchConcurrency", exception.ParamName);
+    }
+
+    [Fact]
+    public void Parallelism_Should_Throw_When_ConnectionFactory_Is_Null()
+    {
+        // Arrange
+        ConnectionFactory connectionFactory = null;
+
+        // Act & Assert
+        _ = Assert.Throws<ArgumentNullException>(() => connectionFactory.Parallelism(1));
+    }
+
     [Fact]
     public void Unbox_Should_Convert_IConnectionFactory_To_ConnectionFactory()
     {


### PR DESCRIPTION
## O que muda

`RabbitMQExtensions.Parallelism(this ConnectionFactory, int)` recebe um `int` mas atribui a `ConsumerDispatchConcurrency`, que é `ushort`, via cast unchecked. Já validava `null` e `negativo ou zero`, mas não o limite superior.

Consequência: `Parallelism(65536)` produzia `ConsumerDispatchConcurrency == 0` — dispatch **desabilitado** — em silêncio. A chamada compilava, rodava, e o consumo de mensagens simplesmente não acontecia.

A correção adiciona `ArgumentOutOfRangeException.ThrowIfGreaterThan(consumerDispatchConcurrency, ushort.MaxValue)` antes da atribuição. O cast permanece unchecked, mas agora é dominado por uma pré-condição que garante `1 <= valor <= 65535`.

Também preenchi o `<summary>` do XML doc, que estava vazio, e documentei o range válido e a exceção.

## Testes

`Parallelism` **não tinha nenhuma cobertura** — nem neste branch nem em qualquer ponto do histórico (`git log -S ... --all` vazio). Os 8 casos adicionados são novos, não a atualização de um teste existente:

- limites válidos: `1`, `4`, `ushort.MaxValue` — verifica o valor atribuído e que o retorno é a mesma instância (fluent);
- fora de range: `0`, `-1`, `65536`, `int.MaxValue` — verifica `ArgumentOutOfRangeException` e o `ParamName`;
- `ConnectionFactory` nula.

Suíte completa de unit tests: **216/216 passando** (net10.0).

## Para o revisor: versionamento

Isto é tecnicamente um breaking change — uma chamada que hoje compila e roda passa a lançar. Argumento para tratar como **patch** e não major:

- **Nenhum chamador no repositório.** Nem `src/`, nem `samples/`, nem `benchmarks/`, nem testes chamam `Parallelism`. Os samples configuram `ConsumerDispatchConcurrency` direto na factory.
- **O caminho principal da API nunca teve o defeito.** `ConsumerDescriptor.WithDispatchConcurrency(ushort)` recebe `ushort` e é protegido pelo compilador. `Parallelism(int)` é o único ponto público que aceita `int` e faz o cast.
- **O conjunto afetado é exatamente `{ v : v > 65535 }`, e já estava quebrado.** Quem passava `65536` não obtinha paralelismo alto demais; obtinha paralelismo nenhum. Trocar falha silenciosa por falha alta no setup é estritamente melhor.
- A `1.10.0` ainda está em `-alpha`, então dá para embarcar aqui sem custo.

Vale registrar no changelog como *behavior change*: quem alimenta esse valor a partir de configuração externa vai ver a aplicação parar de subir, e merece saber o motivo.

Alternativa conservadora, caso prefira: fazer clamp para `ushort.MaxValue` com log de warning em vez de lançar. Não recomendo — 65535 dispatchers concorrentes já é patológico, e mascarar o erro é o que produziu este bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
